### PR TITLE
Fix method-name collisions

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -127,7 +127,7 @@ func (c *comparer) compareMajor(older, newer map[string]*packages.Package) Resul
 		)
 
 		for id, obj := range topObjs {
-			if !ast.IsExported(id) {
+			if !isExported(id) {
 				continue
 			}
 			if newPkg == nil {
@@ -162,7 +162,7 @@ func (c *comparer) compareMinor(older, newer map[string]*packages.Package) Resul
 		)
 
 		for id, obj := range topObjs {
-			if !ast.IsExported(id) {
+			if !isExported(id) {
 				continue
 			}
 			if oldPkg == nil {
@@ -351,4 +351,13 @@ func (cb cloneBugErr) Error() string {
 
 func (cb cloneBugErr) Unwrap() error {
 	return cb.err
+}
+
+// Calls ast.IsExported on the final element of name
+// (which may be package/type-qualified).
+func isExported(name string) bool {
+	if i := strings.LastIndex(name, "."); i > 0 {
+		name = name[i+1:]
+	}
+	return ast.IsExported(name)
 }

--- a/testdata/minor/familiarmethodname.tmpl
+++ b/testdata/minor/familiarmethodname.tmpl
@@ -1,0 +1,28 @@
+//// -*- mode: go -*-
+
+//// {{ define "older" }}
+
+package familiarmethodname
+
+type Val int
+
+const String Val = 1
+
+//// {{ end }}
+
+//// {{ define "newer" }}
+
+package familiarmethodname
+
+type Val int
+
+const String Val = 1
+
+func (v *Val) String() string {
+	switch *v {
+		case String: return "string"
+	}
+	return "<unknown>"
+}
+
+//// {{ end }}

--- a/types.go
+++ b/types.go
@@ -613,10 +613,11 @@ func makeTopObjs(pkg *packages.Package) map[string]types.Object {
 			case *ast.FuncDecl:
 				// If decl is a method, qualify the name with the receiver type.
 				name := decl.Name.Name
-				if decl.Recv != nil {
+				if decl.Recv != nil && len(decl.Recv.List) > 0 {
 					recv := decl.Recv.List[0].Type
-					info := pkg.TypesInfo.Types[recv]
-					name = types.TypeString(info.Type, types.RelativeTo(pkg.Types)) + "." + name
+					if info := pkg.TypesInfo.Types[recv]; info.Type != nil {
+						name = types.TypeString(info.Type, types.RelativeTo(pkg.Types)) + "." + name
+					}
 				}
 
 				res[name] = pkg.TypesInfo.Defs[decl.Name]

--- a/types.go
+++ b/types.go
@@ -611,7 +611,15 @@ func makeTopObjs(pkg *packages.Package) map[string]types.Object {
 				}
 
 			case *ast.FuncDecl:
-				res[decl.Name.Name] = pkg.TypesInfo.Defs[decl.Name]
+				// If decl is a method, qualify the name with the receiver type.
+				name := decl.Name.Name
+				if decl.Recv != nil {
+					recv := decl.Recv.List[0].Type
+					info := pkg.TypesInfo.Types[recv]
+					name = types.TypeString(info.Type, types.RelativeTo(pkg.Types)) + "." + name
+				}
+
+				res[name] = pkg.TypesInfo.Defs[decl.Name]
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes #18 by qualifying method names with their receiver types in the result of `makeTopObjs`. There is a new regression test in testdata/minor/familiarmethodname.tmpl.