### PR TITLE
Fix PRs made from forks

### DIFF
--- a/internal/pr.go
+++ b/internal/pr.go
@@ -18,7 +18,7 @@ import (
 
 // PR performs modver analysis on a GitHub pull request.
 func PR(ctx context.Context, gh *github.Client, owner, reponame string, prnum int) (modver.Result, error) {
-	return prHelper(ctx, gh.Repositories, gh.PullRequests, gh.Issues, modver.CompareGit, owner, reponame, prnum)
+	return prHelper(ctx, gh.Repositories, gh.PullRequests, gh.Issues, modver.CompareGit2, owner, reponame, prnum)
 }
 
 type reposIntf interface {
@@ -35,7 +35,7 @@ type issuesIntf interface {
 	ListComments(ctx context.Context, owner, reponame string, number int, opts *github.IssueListCommentsOptions) ([]*github.IssueComment, *github.Response, error)
 }
 
-func prHelper(ctx context.Context, repos reposIntf, prs prsIntf, issues issuesIntf, comparer func(ctx context.Context, cloneURL, baseSHA, headSHA string) (modver.Result, error), owner, reponame string, prnum int) (modver.Result, error) {
+func prHelper(ctx context.Context, repos reposIntf, prs prsIntf, issues issuesIntf, comparer func(ctx context.Context, baseURL, baseSHA, headURL, headSHA string) (modver.Result, error), owner, reponame string, prnum int) (modver.Result, error) {
 	repo, _, err := repos.Get(ctx, owner, reponame)
 	if err != nil {
 		return modver.None, errors.Wrap(err, "getting repository")
@@ -44,7 +44,7 @@ func prHelper(ctx context.Context, repos reposIntf, prs prsIntf, issues issuesIn
 	if err != nil {
 		return modver.None, errors.Wrap(err, "getting pull request")
 	}
-	result, err := comparer(ctx, *repo.CloneURL, *pr.Base.SHA, *pr.Head.SHA)
+	result, err := comparer(ctx, *pr.Base.Repo.CloneURL, *pr.Base.SHA, *pr.Head.Repo.CloneURL, *pr.Head.SHA)
 	if err != nil {
 		return modver.None, errors.Wrap(err, "comparing versions")
 	}

--- a/internal/pr_test.go
+++ b/internal/pr_test.go
@@ -70,8 +70,18 @@ type mockPRsService struct{}
 
 func (mockPRsService) Get(ctx context.Context, owner, reponame string, number int) (*github.PullRequest, *github.Response, error) {
 	return &github.PullRequest{
-		Base:   &github.PullRequestBranch{SHA: ptr("baseSHA")},
-		Head:   &github.PullRequestBranch{SHA: ptr("headSHA")},
+		Base: &github.PullRequestBranch{
+			Repo: &github.Repository{
+				CloneURL: ptr("baseURL"),
+			},
+			SHA: ptr("baseSHA"),
+		},
+		Head: &github.PullRequestBranch{
+			Repo: &github.Repository{
+				CloneURL: ptr("headURL"),
+			},
+			SHA: ptr("headSHA"),
+		},
 		Number: ptr(17),
 	}, nil, nil
 }
@@ -113,8 +123,8 @@ func (m *mockIssuesService) ListComments(ctx context.Context, owner, reponame st
 	return result, nil, nil
 }
 
-func mockComparer(result modver.Result) func(ctx context.Context, cloneURL, baseSHA, headSHA string) (modver.Result, error) {
-	return func(ctx context.Context, cloneURL, baseSHA, headSHA string) (modver.Result, error) {
+func mockComparer(result modver.Result) func(_ context.Context, _, _, _, _ string) (modver.Result, error) {
+	return func(_ context.Context, _, _, _, _ string) (modver.Result, error) {
 		return result, nil
 	}
 }


### PR DESCRIPTION
This PR fixes `modver -pr` in the case where the PR involves two different repos. Closes #23.