### PR TITLE
Cache the result of comparer.identical for a massive speedup

### DIFF
--- a/identical.go
+++ b/identical.go
@@ -3,7 +3,13 @@ package modver
 import "go/types"
 
 // https://golang.org/ref/spec#Type_identity
-func (c *comparer) identical(a, b types.Type) bool {
+func (c *comparer) identical(a, b types.Type) (res bool) {
+	tp := typePair{a: a, b: b}
+	if res, ok := c.identicache[tp]; ok {
+		return res
+	}
+	defer func() { c.identicache[tp] = res }()
+
 	if types.Identical(a, b) {
 		return true
 	}

--- a/types.go
+++ b/types.go
@@ -12,14 +12,18 @@ import (
 
 type (
 	comparer struct {
-		stack []typePair
-		cache map[typePair]Result
+		stack       []typePair
+		cache       map[typePair]Result
+		identicache map[typePair]bool
 	}
 	typePair struct{ a, b types.Type }
 )
 
 func newComparer() *comparer {
-	return &comparer{cache: make(map[typePair]Result)}
+	return &comparer{
+		cache:       make(map[typePair]Result),
+		identicache: make(map[typePair]bool),
+	}
 }
 
 func (c *comparer) compareTypes(older, newer types.Type) (res Result) {


### PR DESCRIPTION
This PR adds a memoizing cache to the `comparer` type for the `identical` method, producing a sometimes enormous speedup.