### PR TITLE
When an interface has unexported methods, adding a method is minor, not major

### DIFF
--- a/testdata/minor/addmethod.tmpl
+++ b/testdata/minor/addmethod.tmpl
@@ -1,0 +1,20 @@
+// -*- mode: go -*-
+
+// {{ define "older" }}
+package addmethod
+
+type X interface {
+  A() int
+	unexported()
+}
+// {{ end }}
+
+// {{ define "newer" }}
+package addmethod
+
+type X interface {
+	A() int
+	B() string
+	unexported()
+}
+// {{ end }}

--- a/testdata/minor/addmethod1.tmpl
+++ b/testdata/minor/addmethod1.tmpl
@@ -1,7 +1,7 @@
 // -*- mode: go -*-
 
 // {{ define "older" }}
-package addmethod
+package addmethod1
 
 type X interface {
   A() int
@@ -10,7 +10,7 @@ type X interface {
 // {{ end }}
 
 // {{ define "newer" }}
-package addmethod
+package addmethod1
 
 type X interface {
 	A() int

--- a/testdata/minor/addmethod2.tmpl
+++ b/testdata/minor/addmethod2.tmpl
@@ -1,0 +1,34 @@
+// -*- mode: go -*-
+
+// {{ define "older/internal/q.go" }}
+package internal
+
+type Q int
+// {{ end }}
+
+// {{ define "newer/internal/q.go" }}
+package internal
+
+type Q int
+// {{ end }}
+
+// {{ define "older" }}
+package addmethod2
+
+import "addmethod2/internal"
+
+type X interface {
+  A() internal.Q
+}
+// {{ end }}
+
+// {{ define "newer" }}
+package addmethod2
+
+import "addmethod2/internal"
+
+type X interface {
+	A() internal.Q
+	B() string
+}
+// {{ end }}


### PR DESCRIPTION
When you add a new method to a type, that's a minor-version change: safe for existing callers to use, but providing new behavior for new code that wants to use it.

But when you add a new method M to an interface, it's a major-version change. Why? Because a caller may have defined its own type T implementing the interface, and if they upgrade, T no longer does unless and until it implements M.

However! Some interfaces are not meant to be implemented outside of the modules in which they're defined. Case in point: [EnumDescriptor](https://pkg.go.dev/google.golang.org/protobuf@v1.34.0/reflect/protoreflect#EnumDescriptor). It prevents callers from implementing that interface by including [an unexported method](https://github.com/protocolbuffers/protobuf-go/blob/ec47fd138f9221b19a2afd6570b3c39ede9df3dc/reflect/protoreflect/type.go#L547).

Adding a method to such an interface cannot break calling code, and so is not a major-version change.

This PR demotes a method-added-to-an-interface change from Major to Minor in the specific case where the interface in question contains unexported methods and/or is defined in terms of "internal" types that callers cannot access.

Fixes #28.